### PR TITLE
Added logging config and run.bat git branch configurability

### DIFF
--- a/azure-app-service-webjobs/run.bat
+++ b/azure-app-service-webjobs/run.bat
@@ -1,12 +1,16 @@
 REM *** DOWNLOAD AND BUILD THE PROJECT ***
+echo Git Branch: %APIMEVENTS-GIT-BRANCH% LogLevel: %APIMEVENTS-LOG-LEVEL%
+if "%APIMEVENTS-GIT-BRANCH%" == "" set APIMEVENTS-GIT-BRANCH="master"
+if "%APIMEVENTS-LOG-LEVEL%"  == "" set APIMEVENTS-LOG-LEVEL="Warn"
+echo Git Branch: %APIMEVENTS-GIT-BRANCH% LogLevel: %APIMEVENTS-LOG-LEVEL%
 rmdir %TEMP%\app /s /q
 mkdir %TEMP%\app
 cd %TEMP%\app
-git clone https://github.com/Moesif/ApimEventProcessor
+git clone -b %APIMEVENTS-GIT-BRANCH% https://github.com/Moesif/ApimEventProcessor
 cd ApimEventProcessor\src\ApimEventProcessor
 dotnet clean
 nuget install packages.config
 dotnet build --configuration "Release"
 cd bin\Release
-
+echo "Launching the app"
 ApimEventProcessor.exe

--- a/src/ApimEventProcessor/ApimEventProcessor.cs
+++ b/src/ApimEventProcessor/ApimEventProcessor.cs
@@ -50,7 +50,7 @@ namespace ApimEventProcessor
             foreach (EventData eventData in messages)
             {
                 var evt = displayableEvent(context, eventData);
-                _Logger.LogInfo("Event received: " + evt);
+                _Logger.LogDebug("Event received: " + evt);
                 try
                 {
                     var httpMessage = HttpMessage.Parse(eventData.GetBodyStream());

--- a/src/ApimEventProcessor/ConsoleLogger.cs
+++ b/src/ApimEventProcessor/ConsoleLogger.cs
@@ -56,4 +56,31 @@ namespace ApimEventProcessor
         }
 
     }
+
+    class LogLevelUtil
+    {
+        public static LogLevel getLevelFromString(String desiredLevel, LogLevel defaultLevel)
+        {
+            LogLevel l = defaultLevel;
+            if (matchesStr(desiredLevel, "debug") || matchesStr(desiredLevel, "trace") )
+                l = LogLevel.Debug;
+            else if (matchesStr(desiredLevel, "information"))
+                l = LogLevel.Info;
+            else if (matchesStr(desiredLevel, "warning"))
+                l = LogLevel.Warning;
+            else if (matchesStr(desiredLevel, "error") || matchesStr(desiredLevel, "fatal"))
+                l = LogLevel.Error;
+            return l;
+        }
+
+        private static Boolean matchesStr(String desiredLevel, String match)
+        {
+            Boolean m = false;
+            if (!string.IsNullOrEmpty(desiredLevel))
+                desiredLevel = desiredLevel.Replace("\"", "").Replace("'", "").Trim().ToLower();
+            if (!string.IsNullOrWhiteSpace(desiredLevel))
+                m = match.Trim().ToLower().StartsWith(desiredLevel);
+            return m;
+        }
+    }
 }

--- a/src/ApimEventProcessor/Helpers/ParamConfig.cs
+++ b/src/ApimEventProcessor/Helpers/ParamConfig.cs
@@ -34,6 +34,13 @@ namespace ApimEventProcessor.Helpers
         public const string STORAGEACCOUNT_KEY = "APIMEVENTS-STORAGEACCOUNT-KEY";
     }
 
+    public static class AppExecuteParams
+    {
+        // Optional:
+        // This log level May be configured in azure web app config env vars
+        public const string APIMEVENTS_LOG_LEVEL = "APIMEVENTS-LOG-LEVEL";
+    }
+
     public static class RunParams
     {
         // Frequency at which events are checkpointed to Azure Storage.
@@ -41,6 +48,7 @@ namespace ApimEventProcessor.Helpers
         
         // Frequency at which Moesif configuration is fetched.
         public const int CONFIG_FETCH_INTERVAL_MINUTES = 5;
+        
     }    
     
     class ParamConfig

--- a/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
+++ b/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
@@ -99,7 +99,7 @@ namespace ApimEventProcessor
             var completedMessages = RemoveCompletedMessages();
             if (completedMessages.Count > 0)
             {
-                _Logger.LogDebug("Sending completed Messages to Moesif. Count: [" + completedMessages.Count + "]");
+                _Logger.LogInfo("Sending completed Messages to Moesif. Count: [" + completedMessages.Count + "]");
                 var moesifEvents = await BuildMoesifEvents(completedMessages);
                 // Send async to Moesif. To send synchronously, use CreateEventsBatch instead
                 await _MoesifClient.Api.CreateEventsBatchAsync(moesifEvents);
@@ -176,7 +176,7 @@ namespace ApimEventProcessor
         From Http request and response, construct the moesif EventModel
         */
         public async Task<EventModel> BuildMoesifEvent(HttpMessage request, HttpMessage response){
-            _Logger.LogDebug("Building Moesif event");
+            _Logger.LogDebug("Building Moesif event: [" + request.MessageId + "]");
             EventRequestModel moesifRequest = await genEventRequestModel(request,
                                                                         ReqHeadersName,
                                                                         RequestTimeName,

--- a/src/ApimEventProcessor/Program.cs
+++ b/src/ApimEventProcessor/Program.cs
@@ -14,8 +14,9 @@ namespace ApimEventProcessor
     {
         static void Main(string[] args)
         {
+            var infoLogger = new ConsoleLogger(LogLevel.Info);
+            infoLogger.LogInfo("STARTING Moesif API Management Event Processor. Reading environment variables");
             var logger = GetLogger();
-            logger.LogInfo("STARTING Moesif API Management Event Processor. Reading environment variables");
             // Load configuration paramaters from Environment
             string eventHubConnectionString = ParamConfig.loadNonEmpty(AzureAppParamNames.EVENTHUB_CONN_STRING);
             string eventHubName = ParamConfig.loadNonEmpty(AzureAppParamNames.EVENTHUB_NAME); 

--- a/src/ApimEventProcessor/Program.cs
+++ b/src/ApimEventProcessor/Program.cs
@@ -14,7 +14,7 @@ namespace ApimEventProcessor
     {
         static void Main(string[] args)
         {
-            var logger = new ConsoleLogger(LogLevel.Debug);
+            var logger = GetLogger();
             logger.LogInfo("STARTING Moesif API Management Event Processor. Reading environment variables");
             // Load configuration paramaters from Environment
             string eventHubConnectionString = ParamConfig.loadNonEmpty(AzureAppParamNames.EVENTHUB_CONN_STRING);
@@ -51,6 +51,24 @@ namespace ApimEventProcessor
         {
             return string.Format("DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1}",
                 storageAccountName, storageAccountKey);
-        }   
+        }
+
+        // Read loglevel from environment, else use system default.
+        // APIMEVENTS_LOG_LEVEL takes priority over DEFAULT_LOG_LEVEL
+        // if neither are configured, use warning as log level.
+        public static ConsoleLogger GetLogger()
+        {
+            var aloglevelparam = ParamConfig.loadDefaultEmpty(AppExecuteParams.APIMEVENTS_LOG_LEVEL);
+            var logLevel = LogLevelUtil.getLevelFromString(aloglevelparam, LogLevel.Warning);
+            var infoLogger = new ConsoleLogger(LogLevel.Info);
+            infoLogger.LogInfo("Setting loglevel to: [ " 
+                                + logLevel.ToString() 
+                                + " ] | '" + AppExecuteParams.APIMEVENTS_LOG_LEVEL + "': [ "
+                                + aloglevelparam 
+                                + " ]"
+                                );
+            var logger = new ConsoleLogger(logLevel);
+            return logger;
+        }
     }
 }


### PR DESCRIPTION
1. Added new env variable `APIMEVENTS-LOG-LEVEL` that can take value of `info`, `debug`, `warn` `error`
2. Added new env variable `APIMEVENTS-GIT-BRANCH` that is used by `run.bat` to deploy specific branch of this repo. This will help solve versioning with policy.xml changes.
3. I changed LogLevel.Info is used very infrequently on a continuous/ongoing basis, and used mainly at startup / shutdown (one time).

Both env vars have a default setting in `run.bat` and they can also be overwritten from Azure App Service > `Settings` > `Configuration` in portal.

The app is not tied to any policy.xml updates.