### PR TITLE
Fix request resp time, update user-agent

### DIFF
--- a/src/ApimEventProcessor/ApimEventProcessor.cs
+++ b/src/ApimEventProcessor/ApimEventProcessor.cs
@@ -19,11 +19,15 @@ namespace ApimEventProcessor
         {
             _HttpMessageProcessor = httpMessageProcessor;
             _Logger = logger;
+            _Logger.LogDebug("Initialize ApimHttpEventProcessorFactory");
         }
 
         public IEventProcessor CreateEventProcessor(PartitionContext context)
         {
-            return new ApimEventProcessor(_HttpMessageProcessor, _Logger);
+            var p = new ApimEventProcessor(_HttpMessageProcessor, _Logger);
+            _Logger.LogDebug("CreateEventProcessors: Consumer Group: " + context.ConsumerGroupName);
+            _Logger.LogDebug("CreateEventProcessors: EventHubPaths: " + context.EventHubPath);
+            return p;
         }
     }
 
@@ -41,12 +45,13 @@ namespace ApimEventProcessor
         {
             _MessageContentProcessor = messageContentProcessor;
             _Logger = logger;
+            _Logger.LogDebug("Initialize ApimEventProcessor");
         }
 
 
         async Task IEventProcessor.ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)
         {
-
+            _Logger.LogDebug("Begin: ProcessEventsAsync");
             foreach (EventData eventData in messages)
             {
                 var evt = displayableEvent(context, eventData);
@@ -75,6 +80,7 @@ namespace ApimEventProcessor
                 await context.CheckpointAsync();
                 this.checkpointStopWatch.Restart();
             }
+            _Logger.LogDebug("End: ProcessEventsAsync");
         }
 
         public static string displayableEvent(PartitionContext context, EventData evt)

--- a/src/ApimEventProcessor/ApimMessageParams.cs
+++ b/src/ApimEventProcessor/ApimMessageParams.cs
@@ -10,6 +10,7 @@ namespace ApimEventProcessor
     {
         public static string EVENT_TYPE = "event_type";
         public static string MESSAGE_ID = "message-id";
+        public static string CONTEXT_TIMESTAMP = "contextTimestamp";
     }
 
     public class MessageRequestParams

--- a/src/ApimEventProcessor/Helpers/ParamConfig.cs
+++ b/src/ApimEventProcessor/Helpers/ParamConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace ApimEventProcessor.Helpers
 {
@@ -49,7 +50,13 @@ namespace ApimEventProcessor.Helpers
         // Frequency at which Moesif configuration is fetched.
         public const int CONFIG_FETCH_INTERVAL_MINUTES = 5;
         
-    }    
+    }
+
+    public static class MoesifApiConfig
+    {
+        // version specified in AssemblyInfo.cs
+        public static String USER_AGENT = "moesif azure-apim/" + Assembly.GetExecutingAssembly().FullName.ToString();
+    }
     
     class ParamConfig
     {

--- a/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
+++ b/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
@@ -41,7 +41,7 @@ namespace ApimEventProcessor
         public MoesifHttpMessageProcessor(ILogger logger)
         {
             var appId = ParamConfig.loadNonEmpty(MoesifAppParamNames.APP_ID);
-            _MoesifClient = new MoesifApiClient(appId);
+            _MoesifClient = new MoesifApiClient(appId, MoesifApiConfig.USER_AGENT);
             _SessionTokenKey = ParamConfig.loadDefaultEmpty(MoesifAppParamNames.SESSION_TOKEN);
             _ApiVersion = ParamConfig.loadDefaultEmpty(MoesifAppParamNames.API_VERSION);
             _Logger = logger;

--- a/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
+++ b/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
@@ -40,18 +40,21 @@ namespace ApimEventProcessor
         
         public MoesifHttpMessageProcessor(ILogger logger)
         {
+            _Logger = logger;
+            _Logger.LogDebug("MoesifHttpMessageProcessor start..");
             var appId = ParamConfig.loadNonEmpty(MoesifAppParamNames.APP_ID);
             _MoesifClient = new MoesifApiClient(appId, MoesifApiConfig.USER_AGENT);
             _SessionTokenKey = ParamConfig.loadDefaultEmpty(MoesifAppParamNames.SESSION_TOKEN);
             _ApiVersion = ParamConfig.loadDefaultEmpty(MoesifAppParamNames.API_VERSION);
-            _Logger = logger;
             ScheduleWorkerToFetchConfig();
+            _Logger.LogDebug("MoesifHttpMessageProcessor started");
         }
 
         private void ScheduleWorkerToFetchConfig()
         {
+            _Logger.LogDebug("Schedule Worker To Fetch Config");
             try {
-                new Thread(async () =>
+                var t = new Thread(async () =>
                 {
                     Thread.CurrentThread.IsBackground = true;
                     lastWorkerRun = DateTime.UtcNow;
@@ -61,7 +64,9 @@ namespace ApimEventProcessor
                     {
                         (configETag, samplingPercentage, lastUpdatedTime) = appConfig.parseConfiguration(config, _Logger);
                     }
-                }).Start();
+                });
+                t.Start();
+                _Logger.LogDebug("Schedule Worker To Fetch Config - thread started");
             } catch (Exception ex) {
                 _Logger.LogError("Error while parsing application configuration on initialization - " + ex.ToString());
             }

--- a/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
+++ b/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
@@ -75,7 +75,7 @@ namespace ApimEventProcessor
             try {
                 if (message.HttpRequestMessage != null){
                     _Logger.LogDebug("Received [request] with messageId: [" + message.MessageId + "]");
-                    message.HttpRequestMessage.Properties.Add(RequestTimeName, DateTime.UtcNow);
+                    message.HttpRequestMessage.Properties.Add(RequestTimeName, message.ContextTimestamp);
                     requestsCache.TryAdd(message.MessageId, message);
                 }
                 if (message.HttpResponseMessage != null){
@@ -215,7 +215,7 @@ namespace ApimEventProcessor
             var reqBodyWrapper = BodyUtil.Serialize(reqBody);
             EventRequestModel moesifRequest = new EventRequestModel()
             {
-                Time = (DateTime) h.Properties[RequestTimeName],
+                Time = request.ContextTimestamp,
                 Uri = h.RequestUri.OriginalString,
                 Verb = h.Method.ToString(),
                 Headers = reqHeaders,
@@ -238,7 +238,7 @@ namespace ApimEventProcessor
             var respBodyWrapper = BodyUtil.Serialize(respBody);
             EventResponseModel moesifResponse = new EventResponseModel()
             {
-                Time = DateTime.UtcNow,
+                Time = response.ContextTimestamp,
                 Status = (int) h.StatusCode,
                 IpAddress = null,
                 Headers = respHeaders,

--- a/src/ApimEventProcessor/Program.cs
+++ b/src/ApimEventProcessor/Program.cs
@@ -28,6 +28,7 @@ namespace ApimEventProcessor
             // Create connection string for azure storage account to store checkpoints
             string storageConnectionString = makeStorageAccountConnString(storageAccountName,
                                                                             storageAccountKey);
+            logger.LogDebug("Storage Account: " + storageAccountName);
             string eventProcessorHostName = Guid.NewGuid().ToString();
             var eventProcessorHost = new EventProcessorHost(
                                                 eventProcessorHostName,
@@ -35,7 +36,7 @@ namespace ApimEventProcessor
                                                 eventHubConsumerGroupName,
                                                 eventHubConnectionString,
                                                 storageConnectionString);
-            logger.LogDebug("Registering EventProcessor...");
+            logger.LogInfo("Registering EventProcessor...");
             var httpMessageProcessor = new MoesifHttpMessageProcessor(logger);
             eventProcessorHost.RegisterEventProcessorFactoryAsync(
                 new ApimHttpEventProcessorFactory(httpMessageProcessor, logger));

--- a/src/ApimEventProcessor/Properties/AssemblyInfo.cs
+++ b/src/ApimEventProcessor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.2")]
+[assembly: AssemblyFileVersion("1.0.0.2")]


### PR DESCRIPTION
Fix the `request.time` and `response.time` to read settings from new `policy.xml`. If setting is not found, revert to existing behavior. Also update user agent for apim-client.

https://www.pivotaltracker.com/story/show/181407219