### PR TITLE
#185467153: Improve perf and stop/start experience

### DIFF
--- a/src/ApimEventProcessor/ApimEventProcessor.cs
+++ b/src/ApimEventProcessor/ApimEventProcessor.cs
@@ -52,7 +52,7 @@ namespace ApimEventProcessor
 
         async Task IEventProcessor.ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)
         {
-            _Logger.LogDebug("Begin: ProcessEventsAsync");
+            _Logger.LogDebug($"Begin: ProcessEventsAsync. PartitionId: {context.Lease.PartitionId}");
             var processedCount = 0;
             foreach (EventData eventData in messages)
             {
@@ -81,15 +81,12 @@ namespace ApimEventProcessor
             // so that worker can resume processing from that time back if it restarts.
             if (this.checkpointStopWatch.Elapsed > TimeSpan.FromMinutes(RunParams.CHECKPOINT_MINIMUM_INTERVAL_MINUTES))
             {
-                _Logger.LogInfo("Saving checkpoint. Actual: ["
-                                + this.checkpointStopWatch.Elapsed
-                                + "] mins. minimum configured is : ["
-                                + RunParams.CHECKPOINT_MINIMUM_INTERVAL_MINUTES
-                                + "] mins");
+                _Logger.LogInfo($"Saving checkpoint for partition:[{context.Lease.PartitionId}] offset[{context.Lease.Offset}] seq[{context.Lease.SequenceNumber}] owner[{context.Lease.Owner}]. "
+                                + $"Actual elapsed time: [{this.checkpointStopWatch.Elapsed}] mins. minimum configured is : [{RunParams.CHECKPOINT_MINIMUM_INTERVAL_MINUTES}] mins");
                 await context.CheckpointAsync();
                 this.checkpointStopWatch.Restart();
             }
-            _Logger.LogDebug("End: ProcessEventsAsync");
+            _Logger.LogDebug($"End: ProcessEventsAsync. PartitionId: {context.Lease.PartitionId}");
         }
 
         public static string displayableEvent(PartitionContext context, EventData evt)

--- a/src/ApimEventProcessor/ApimEventProcessor.cs
+++ b/src/ApimEventProcessor/ApimEventProcessor.cs
@@ -40,6 +40,7 @@ namespace ApimEventProcessor
         Stopwatch checkpointStopWatch;
         private ILogger _Logger;
         private IHttpMessageProcessor _MessageContentProcessor;
+        private int MAX_EVENTS_ADD_TOCACHE_BEFORE_SEND = 100;
 
         public ApimEventProcessor(IHttpMessageProcessor messageContentProcessor, ILogger logger)
         {
@@ -52,6 +53,7 @@ namespace ApimEventProcessor
         async Task IEventProcessor.ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)
         {
             _Logger.LogDebug("Begin: ProcessEventsAsync");
+            var processedCount = 0;
             foreach (EventData eventData in messages)
             {
                 var evt = displayableEvent(context, eventData);
@@ -59,7 +61,13 @@ namespace ApimEventProcessor
                 try
                 {
                     var httpMessage = HttpMessage.Parse(eventData.GetBodyStream());
-                    await _MessageContentProcessor.ProcessHttpMessage(httpMessage);
+                    await _MessageContentProcessor.ProcessHttpMessage(httpMessage); // just cache dont send
+                    processedCount += 1;
+                    var isSend = processedCount >= MAX_EVENTS_ADD_TOCACHE_BEFORE_SEND;
+                    if (isSend) {
+                        processedCount = 0;
+                        await _MessageContentProcessor.ProcessHttpMessage(null); // dont add just send
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -67,6 +75,7 @@ namespace ApimEventProcessor
                     _Logger.LogError("Error: " + evt + " - " + ex.Message);
                 }
             }
+            await _MessageContentProcessor.ProcessHttpMessage(null); // dont add just send
 
             //Call checkpoint every CHECKPOINT_MINIMUM_INTERVAL_MINUTES minutes,
             // so that worker can resume processing from that time back if it restarts.

--- a/src/ApimEventProcessor/Helpers/ParamConfig.cs
+++ b/src/ApimEventProcessor/Helpers/ParamConfig.cs
@@ -53,7 +53,7 @@ namespace ApimEventProcessor.Helpers
     public static class RunParams
     {
         // Frequency at which events are checkpointed to Azure Storage.
-        public const int CHECKPOINT_MINIMUM_INTERVAL_MINUTES = 5;
+        public const int CHECKPOINT_MINIMUM_INTERVAL_MINUTES = 1;
         
         // Frequency at which Moesif configuration is fetched.
         public const int CONFIG_FETCH_INTERVAL_MINUTES = 5;

--- a/src/ApimEventProcessor/Helpers/ParamConfig.cs
+++ b/src/ApimEventProcessor/Helpers/ParamConfig.cs
@@ -39,7 +39,7 @@ namespace ApimEventProcessor.Helpers
 
         // Optional: use default if not set
         // see https://learn.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.eventprocessoroptions?view=azure-dotnet#properties
-        // override the default EventHub MaxBatchSize value (at the moment it defaults to 10)
+        // override the default EventHub MaxBatchSize value
         public const string EVENTHUB_MAX_BATCH_SIZE = "APIMEVENTS-EVENTHUB-MAX-BATCH-SIZE";
     }
 
@@ -58,6 +58,7 @@ namespace ApimEventProcessor.Helpers
         // Frequency at which Moesif configuration is fetched.
         public const int CONFIG_FETCH_INTERVAL_MINUTES = 5;
         
+        // EventHub MaxBatchSize value default is 10, a bit too small.
         public const int EVENTHUB_MAX_BATCH_SIZE_DEFAULT = 100;
     }
 

--- a/src/ApimEventProcessor/Helpers/ParamConfig.cs
+++ b/src/ApimEventProcessor/Helpers/ParamConfig.cs
@@ -58,7 +58,7 @@ namespace ApimEventProcessor.Helpers
         // Frequency at which Moesif configuration is fetched.
         public const int CONFIG_FETCH_INTERVAL_MINUTES = 5;
         
-        public const int EVENTHUB_MAX_BATCH_SIZE_DEFAULT = 0;
+        public const int EVENTHUB_MAX_BATCH_SIZE_DEFAULT = 100;
     }
 
     public static class MoesifApiConfig

--- a/src/ApimEventProcessor/Helpers/ParamConfig.cs
+++ b/src/ApimEventProcessor/Helpers/ParamConfig.cs
@@ -36,6 +36,11 @@ namespace ApimEventProcessor.Helpers
 
         // Required
         public const string STORAGEACCOUNT_KEY = "APIMEVENTS-STORAGEACCOUNT-KEY";
+
+        // Optional: use default if not set
+        // see https://learn.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.eventprocessoroptions?view=azure-dotnet#properties
+        // override the default EventHub MaxBatchSize value (at the moment it defaults to 10)
+        public const string EVENTHUB_MAX_BATCH_SIZE = "APIMEVENTS-EVENTHUB-MAX-BATCH-SIZE";
     }
 
     public static class AppExecuteParams
@@ -53,6 +58,7 @@ namespace ApimEventProcessor.Helpers
         // Frequency at which Moesif configuration is fetched.
         public const int CONFIG_FETCH_INTERVAL_MINUTES = 5;
         
+        public const int EVENTHUB_MAX_BATCH_SIZE_DEFAULT = 0;
     }
 
     public static class MoesifApiConfig

--- a/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
+++ b/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
@@ -78,22 +78,24 @@ namespace ApimEventProcessor
             }
         }
 
+        // if message is not null, add to cache/dont send. If message is null.. only attempt to send
         public async Task ProcessHttpMessage(HttpMessage message)
         {
             // message will probably contain either HttpRequestMessage or HttpResponseMessage
             // So we cache both request and response and cache them. 
             // Note, response message might be processed before request
             try {
-                if (message.HttpRequestMessage != null){
+                if (message != null && message.HttpRequestMessage != null){
                     _Logger.LogDebug("Received [request] with messageId: [" + message.MessageId + "]");
                     message.HttpRequestMessage.Properties.Add(RequestTimeName, message.ContextTimestamp);
                     requestsCache.TryAdd(message.MessageId, message);
                 }
-                if (message.HttpResponseMessage != null){
+                if (message != null && message.HttpResponseMessage != null){
                     _Logger.LogDebug("Received [response] with messageId: [" + message.MessageId + "]");
                     responsesCache.TryAdd(message.MessageId, message);
                 }
-                await SendCompletedMessagesToMoesif();
+                if (message == null)
+                    await SendCompletedMessagesToMoesif();
             }
             catch (Exception ex) {
                  _Logger.LogError("Error Processing and sending message to Moesif:  " + ex.Message);
@@ -120,12 +122,21 @@ namespace ApimEventProcessor
         public Dictionary<Guid, KeyValuePair<HttpMessage, HttpMessage>> RemoveCompletedMessages(){
             Dictionary<Guid, KeyValuePair<HttpMessage, HttpMessage>> messages = new Dictionary<Guid, KeyValuePair<HttpMessage, HttpMessage>>();
             lock(qLock){
-                foreach(Guid messageId in requestsCache.Keys.Intersect(responsesCache.Keys))
+                var reqCacheSizeBefore = requestsCache.Count;
+                var respCacheSizeBefore = responsesCache.Count;
+                var commonMessageIds = requestsCache.Keys.Intersect(responsesCache.Keys);
+                foreach(Guid messageId in commonMessageIds)
                 {
                     HttpMessage reqm, respm;
                     requestsCache.TryRemove(messageId, out reqm);
                     responsesCache.TryRemove(messageId, out respm);
-                    messages.Add(messageId, new KeyValuePair<HttpMessage, HttpMessage>(reqm, respm));
+                    if (null != reqm && null != respm)
+                        messages.Add(messageId, new KeyValuePair<HttpMessage, HttpMessage>(reqm, respm));
+                }
+                if (commonMessageIds.LongCount() > 0) {
+                    var reqDelta = reqCacheSizeBefore - requestsCache.Count;
+                    var respCache = respCacheSizeBefore - responsesCache.Count;
+                    _Logger.LogInfo($"Before/After CommonMessages:[{messages.Count}|{reqDelta}|{respCache}] RequestsCache: [{reqCacheSizeBefore}/{requestsCache.Count}] ResponsesCache: [{respCacheSizeBefore}/{responsesCache.Count}]");
                 }
             }
             return messages;

--- a/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
+++ b/src/ApimEventProcessor/MoesifHttpMessageProcessor.cs
@@ -122,8 +122,8 @@ namespace ApimEventProcessor
         public Dictionary<Guid, KeyValuePair<HttpMessage, HttpMessage>> RemoveCompletedMessages(){
             Dictionary<Guid, KeyValuePair<HttpMessage, HttpMessage>> messages = new Dictionary<Guid, KeyValuePair<HttpMessage, HttpMessage>>();
             lock(qLock){
-                var reqCacheSizeBefore = requestsCache.Count;
-                var respCacheSizeBefore = responsesCache.Count;
+                //var reqCacheSizeBefore = requestsCache.Count;
+                //var respCacheSizeBefore = responsesCache.Count;
                 var commonMessageIds = requestsCache.Keys.Intersect(responsesCache.Keys);
                 foreach(Guid messageId in commonMessageIds)
                 {
@@ -133,11 +133,11 @@ namespace ApimEventProcessor
                     if (null != reqm && null != respm)
                         messages.Add(messageId, new KeyValuePair<HttpMessage, HttpMessage>(reqm, respm));
                 }
-                if (commonMessageIds.LongCount() > 0) {
-                    var reqDelta = reqCacheSizeBefore - requestsCache.Count;
-                    var respCache = respCacheSizeBefore - responsesCache.Count;
-                    _Logger.LogInfo($"Before/After CommonMessages:[{messages.Count}|{reqDelta}|{respCache}] RequestsCache: [{reqCacheSizeBefore}/{requestsCache.Count}] ResponsesCache: [{respCacheSizeBefore}/{responsesCache.Count}]");
-                }
+                //if (commonMessageIds.LongCount() > 0) {
+                //    var reqDelta = reqCacheSizeBefore - requestsCache.Count;
+                //    var respCache = respCacheSizeBefore - responsesCache.Count;
+                //    _Logger.LogInfo($"Before/After CommonMessages:[{messages.Count}|{reqDelta}|{respCache}] RequestsCache: [{reqCacheSizeBefore}/{requestsCache.Count}] ResponsesCache: [{respCacheSizeBefore}/{responsesCache.Count}]");
+                //}
             }
             return messages;
         }

--- a/src/ApimEventProcessor/Program.cs
+++ b/src/ApimEventProcessor/Program.cs
@@ -83,7 +83,7 @@ namespace ApimEventProcessor
                 AzureAppParamNames.EVENTHUB_MAX_BATCH_SIZE,
                 RunParams.EVENTHUB_MAX_BATCH_SIZE_DEFAULT);
             var oldMaxBatchSize = epOptions.MaxBatchSize;
-            if (maxSizeFromConfig > RunParams.EVENTHUB_MAX_BATCH_SIZE_DEFAULT) {
+            if (maxSizeFromConfig > 0) {
                 epOptions.MaxBatchSize = maxSizeFromConfig;
                 infoLogger.LogInfo($"Overriding the default Eventhub MaxBatchSize. Old default value:[{oldMaxBatchSize}] New value:[{epOptions.MaxBatchSize}]");
             } else {

--- a/src/ApimEventProcessor/Program.cs
+++ b/src/ApimEventProcessor/Program.cs
@@ -72,5 +72,22 @@ namespace ApimEventProcessor
             var logger = new ConsoleLogger(logLevel);
             return logger;
         }
+
+        public static EventProcessorOptions buildEventProcessorOptions()
+        {
+            var infoLogger = new ConsoleLogger(LogLevel.Info);
+            EventProcessorOptions epOptions = new EventProcessorOptions();
+            int maxSizeFromConfig = ParamConfig.loadWithDefault(
+                AzureAppParamNames.EVENTHUB_MAX_BATCH_SIZE,
+                RunParams.EVENTHUB_MAX_BATCH_SIZE_DEFAULT);
+            var oldMaxBatchSize = epOptions.MaxBatchSize;
+            if (maxSizeFromConfig > RunParams.EVENTHUB_MAX_BATCH_SIZE_DEFAULT) {
+                epOptions.MaxBatchSize = maxSizeFromConfig;
+                infoLogger.LogInfo($"Overriding the default Eventhub MaxBatchSize. Old default value:[{oldMaxBatchSize}] New value:[{epOptions.MaxBatchSize}]");
+            } else {
+                infoLogger.LogInfo($"Using default Eventhub MaxBatchSize:[{epOptions.MaxBatchSize}] (to override set env var {AzureAppParamNames.EVENTHUB_MAX_BATCH_SIZE})");
+            }
+            return epOptions;
+        }
     }
 }

--- a/src/ApimEventProcessor/Program.cs
+++ b/src/ApimEventProcessor/Program.cs
@@ -39,7 +39,9 @@ namespace ApimEventProcessor
             logger.LogInfo("Registering EventProcessor...");
             var httpMessageProcessor = new MoesifHttpMessageProcessor(logger);
             eventProcessorHost.RegisterEventProcessorFactoryAsync(
-                new ApimHttpEventProcessorFactory(httpMessageProcessor, logger));
+                new ApimHttpEventProcessorFactory(httpMessageProcessor, logger),
+                buildEventProcessorOptions()
+            );
             
             logger.LogInfo("Process is running. Press enter key to end...");
             Console.ReadLine();

--- a/src/ApimEventProcessor/Properties/AssemblyInfo.cs
+++ b/src/ApimEventProcessor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.6")]
-[assembly: AssemblyFileVersion("1.0.0.6")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]


### PR DESCRIPTION
* Modify logic on how and when requests are matched to responses to improve performance.
* Override the default EventHub `MaxBatchSize` (`10`) to make it configurable by env vars, with `100` as default.
* Change eventhub `checkpoint` to `1 min` to improve stop/start experience.
* Minor changes to logging, bump to version `1.0.1.0`